### PR TITLE
For compatibility with Python 3.x

### DIFF
--- a/tfidf.py
+++ b/tfidf.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+# -*- coding: utf-8 -*-
 
 """
 The simplest TF-IDF library imaginable.
@@ -51,7 +52,7 @@ class tfidf:
       score = 0.0
       doc_dict = doc[1]
       for k in query_dict:
-        if doc_dict.has_key(k):
+        if k in doc_dict:
           score += (query_dict[k] / self.corpus_dict[k]) + (doc_dict[k] / self.corpus_dict[k])
       sims.append([doc[0], score])
 


### PR DESCRIPTION
Method dictionaries:
```Python
Dict.has_key('key')
```
It's only in Python 2.x. Therefore it doesn'tt work in Python 3.x.
But there is a similar operation, which is supported by all versions Python:
```Python
'key' in Dict
```